### PR TITLE
TASK: Update logger calls introduced by Flow 6

### DIFF
--- a/Classes/Aspects/ThumbnailAspect.php
+++ b/Classes/Aspects/ThumbnailAspect.php
@@ -3,7 +3,6 @@ namespace Sitegeist\Origami\Aspects;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
-use Neos\Flow\Log\SystemLoggerInterface;
 use Sitegeist\Origami\Service\ImageOptimizationService;
 
 /**
@@ -12,12 +11,6 @@ use Sitegeist\Origami\Service\ImageOptimizationService;
  */
 class ThumbnailAspect
 {
-    /**
-     * @var SystemLoggerInterface
-     * @Flow\Inject
-     */
-    protected $systemLogger;
-
     /**
      * @var array
      * @Flow\InjectConfiguration

--- a/Classes/Service/ImageOptimizationService.php
+++ b/Classes/Service/ImageOptimizationService.php
@@ -4,8 +4,9 @@ namespace Sitegeist\Origami\Service;
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\CompilingEvaluator;
 use Neos\Eel\Utility;
-use Neos\Flow\Log\SystemLoggerInterface;
 use Flowpack\JobQueue\Common\Annotations as Job;
+use Psr\Log\LoggerInterface;
+use Neos\Flow\Log\Utility\LogEnvironment;
 
 /**
  * @Flow\Scope("singleton")
@@ -13,7 +14,7 @@ use Flowpack\JobQueue\Common\Annotations as Job;
 class ImageOptimizationService
 {
     /**
-     * @var SystemLoggerInterface
+     * @var LoggerInterface
      * @Flow\Inject
      */
     protected $systemLogger;
@@ -49,12 +50,12 @@ class ImageOptimizationService
             $failed = (int)$result !== 0;
 
             if ($failed) {
-                $this->systemLogger->log($commandEvaluated, LOG_ERR, $output);
+                $this->systemLogger->error($commandEvaluated, array_merge(LogEnvironment::fromMethodName(__METHOD__), $output));
             } else {
-                $this->systemLogger->log($commandEvaluated, LOG_INFO, $output);
+                $this->systemLogger->info($commandEvaluated, array_merge(LogEnvironment::fromMethodName(__METHOD__), $output));
             }
         } else {
-            $this->systemLogger->log(sprintf('Could not optimize image %s of type %s because missing or disabled configuration', $file, $imageType), LOG_ERR);
+            $this->systemLogger->error(sprintf('Could not optimize image %s of type %s because missing or disabled configuration', $file, $imageType));
         }
     }
 


### PR DESCRIPTION
I try to upgrade a project to Neos 5.3 and this packages uses the old systemLogger interface.
With this PR I updated the logger to support the new Flow 6.0 Interface.

The logging of `$output` is copied from
https://github.com/mocdk/MOC.ImageOptimizer/blob/master/Classes/Aspects/ThumbnailAspect.php#L122
